### PR TITLE
move aggregate worker next_state and execute logic into own modules

### DIFF
--- a/lib/headwater/aggregate/execute_wish.ex
+++ b/lib/headwater/aggregate/execute_wish.ex
@@ -1,0 +1,8 @@
+defmodule Headwater.Aggregate.ExecuteWish do
+  def process(aggregate, aggregate_state, wish) do
+    case aggregate.handler.execute(aggregate_state, wish) do
+      {:ok, event} -> {:ok, List.wrap(event)}
+      result -> {:error, :execute, result}
+    end
+  end
+end

--- a/lib/headwater/aggregate/next_state.ex
+++ b/lib/headwater/aggregate/next_state.ex
@@ -1,0 +1,15 @@
+defmodule Headwater.Aggregate.NextState do
+  def process(_aggregate, aggregate_state, []) do
+    {:ok, aggregate_state}
+  end
+
+  def process(aggregate, aggregate_state, [new_event | next_events]) do
+    case aggregate.handler.next_state(aggregate_state, new_event) do
+      response = {:error, reason} ->
+        {:error, :next_state, response}
+
+      new_aggregate_state ->
+        process(aggregate, new_aggregate_state, next_events)
+    end
+  end
+end


### PR DESCRIPTION
Just a refactor, to make the logic in the aggregate worker clearer, and the handler's `next_state` and `execute` logic clearer also.