### PR TITLE
bug where reading events for an aggregate would load all the events in total

### DIFF
--- a/example/lib/example/counter.ex
+++ b/example/lib/example/counter.ex
@@ -12,7 +12,7 @@ defmodule Example.Counter do
   end
 
   def execute(current_state, wish = %Example.Increment{}) do
-    {:ok, %Example.Incremented{increment_by: wish.increment_by}}
+    {:ok, %Example.Incremented{counter_id: wish.counter_id, increment_by: wish.increment_by}}
   end
 
   def next_state(nil, event) do

--- a/example/test/headwater_internal/event_store_test.exs
+++ b/example/test/headwater_internal/event_store_test.exs
@@ -1,0 +1,31 @@
+defmodule Example.HeadwaterInternal.EventStoreTest do
+  use ExUnit.Case
+  use Headwater.TestHelper, repo: Example.Repo
+
+  test "writes & reads one event" do
+    aggregate_id = "counter_" <> Headwater.uuid()
+
+    Example.Router.handle(%Example.Increment{
+      counter_id: aggregate_id,
+      increment_by: 5
+    })
+
+    assert result =
+             [
+               %{
+                 aggregate_id: aggregate_id,
+                 aggregate_number: 1,
+                 created_at: _created_at,
+                 data: %{counter_id: aggregate_id, increment_by: 5},
+                 event_id: _event_id,
+                 event_number: _event_number,
+                 event_type: "Elixir.Example.Incremented",
+                 idempotency_key: _indempotency_key
+               }
+             ] =
+             Example.EventStore.load_events_for_aggregate(aggregate_id)
+             |> Headwater.Debug.to_list()
+
+    assert Enum.count(result) == 1
+  end
+end

--- a/lib/headwater/event_store/adapters/postgres.ex
+++ b/lib/headwater/event_store/adapters/postgres.ex
@@ -36,33 +36,35 @@ defmodule Headwater.EventStore.Adapters.Postgres do
           ReadStream.read(
             fn next_event_number ->
               Query.recorded_events(from_event_number: next_event_number)
-              |> execute__and_decode_events()
+              |> execute_and_decode_events()
             end,
-            starting_event_number: starting_event_number
+            starting_event_number
           )
 
         {:ok, recorded_events_stream}
       end
 
       @impl Headwater.EventStore
-      def load_events_for_aggregate(aggregate_id, starting_event_number \\ 0) do
+      def load_events_for_aggregate(aggregate_id, starting_aggregate_number \\ 0) do
         Logger.info(fn ->
-          "Loading events for aggregate #{aggregate_id} from #{starting_event_number}."
+          "Loading events for aggregate #{aggregate_id} from aggregate number #{
+            starting_aggregate_number
+          }."
         end)
 
         recorded_events_stream =
           ReadStream.read(
-            fn next_event_number ->
-              Query.recorded_events(aggregate_id, from_event_number: next_event_number)
-              |> execute__and_decode_events()
+            fn next_aggregate_number ->
+              Query.recorded_events(aggregate_id, from_aggregate_number: next_aggregate_number)
+              |> execute_and_decode_events()
             end,
-            starting_event_number: starting_event_number
+            starting_aggregate_number
           )
 
         {:ok, recorded_events_stream}
       end
 
-      defp execute__and_decode_events(query) do
+      defp execute_and_decode_events(query) do
         deserialized_events =
           query
           |> @repo.all()

--- a/lib/headwater/event_store/adapters/postgres/query.ex
+++ b/lib/headwater/event_store/adapters/postgres/query.ex
@@ -19,11 +19,12 @@ defmodule Headwater.EventStore.Adapters.Postgres.Query do
   end
 
   def recorded_events(aggregate_id, opts) do
-    {from_event_number, opts} = Keyword.pop(opts, :from_event_number, 0)
+    {from_aggregate_number, opts} = Keyword.pop(opts, :from_aggregate_number, 0)
     {read_batch_size, opts} = Keyword.pop(opts, :read_batch, @default_batch_read_size)
 
     from(event in HeadwaterEventsSchema,
-      where: event.aggregate_id == ^aggregate_id and event.event_number > ^from_event_number,
+      where:
+        event.aggregate_id == ^aggregate_id and event.aggregate_number > ^from_aggregate_number,
       order_by: [asc: event.event_number],
       limit: ^read_batch_size
     )

--- a/lib/headwater/event_store/adapters/postgres/read_stream.ex
+++ b/lib/headwater/event_store/adapters/postgres/read_stream.ex
@@ -1,13 +1,14 @@
 defmodule Headwater.EventStore.Adapters.Postgres.ReadStream do
-  def read(callback, opts) do
-    {from_event_number, opts} = Keyword.pop(opts, :starting_event_number, 0)
-
+  def read(callback, base_count) do
     Elixir.Stream.resource(
-      fn -> from_event_number end,
-      fn next_event_number ->
-        case callback.(next_event_number) do
-          {:ok, []} -> {:halt, next_event_number}
-          {:ok, events} -> {events, next_event_number + length(events)}
+      fn -> base_count end,
+      fn next_event_count ->
+        case callback.(next_event_count) do
+          {:ok, []} ->
+            {:halt, next_event_count}
+
+          {:ok, events} ->
+            {events, next_event_count + length(events)}
         end
       end,
       fn _ -> :ok end


### PR DESCRIPTION
stream increments for aggregate should not be based on event_number, otherwise minimum events in each aggregate is the total number of events.


**What was wrong?**
The logic for batch loading events for an aggregate was always returning results until all events were loaded due to:
```
where: event.aggregate_id == ^aggregate_id and event.event_number > ^from_event_number
```
which should be:
```
where: event.aggregate_id == ^aggregate_id and event.aggregate_number > ^from_aggregate_number,
```

For example, if total number of events stored was `3000`, but only 5 events in the aggregate, the condition logic meant we'd load all `3000` events because there was always an `event_number` greater than the last `event_number +1` until all 3000 events were loaded.

The condition now checks `aggregate_number` to see if there are any more events on the aggregate to be loaded, which sets the max results returned to the number of events on the aggregate, not the total number.