### PR TITLE
just one ets table for idempotency keys

### DIFF
--- a/lib/headwater/event_store/event_store.ex
+++ b/lib/headwater/event_store/event_store.ex
@@ -17,7 +17,6 @@ defmodule Headwater.EventStore do
   @callback load_events(from_event_number) :: {:ok, [recorded_event]}
   @callback load_events_for_aggregate(aggregate_id) :: {:ok, [recorded_event]}
   @callback event_handled(listener_id: listener_id, event_number: event_number) :: :ok
-  @callback get_event(event_id) :: {:ok, recorded_event}
   @callback get_bus_next_event_number(listener_id, from_event_number) :: event_number
   @callback bus_has_completed_event_number(bus_id: listener_id, event_number: event_number) :: :ok
 end


### PR DESCRIPTION
after concerns about memory leaking from creating a new ets table for each aggregate id that builds an atom for the table name